### PR TITLE
Fix video player size issue when entering fullscreen

### DIFF
--- a/lib/screens/home_eiga/player_eiga.dart
+++ b/lib/screens/home_eiga/player_eiga.dart
@@ -715,66 +715,68 @@ class _PlayerEigaState extends State<PlayerEiga>
           // HELP: delayed widget for fix size not correct if fullscreen change
           child: DelayedWidget(
               delay: const Duration(milliseconds: 222),
-              builder: (context) => LayoutBuilder(
-                    builder: (_, constraints) => Watch(() {
-                      counter.value;
-                      final controller = _controller.value;
-                      if (controller == null) {
-                        return Center(
-                            child: OImage.oNetwork(
-                          widget.metaEiga.value.poster!,
-                          sourceId: widget.service.uid,
-                          fit: BoxFit.cover,
-                        ));
-                      }
+              builder: (context) =>
+                  StatefulBuilder(builder: (context, setState2) {
+                    timerCounter?.cancel();
+                    if (counter.value < 10) {
+                      timerCounter = Timer(Duration(milliseconds: 222), () {
+                        timerCounter = null;
+                        if (context.mounted) setState2(() {});
+                      });
+                    }
 
-                      final maxWidth = _fullscreen.value
-                          ? 100.w(context)
-                          : constraints.biggest.width;
-                      final maxHeight = _fullscreen.value
-                          ? 100.h(context)
-                          : (maxWidth / widget.aspectRatio);
+                    return LayoutBuilder(
+                      builder: (_, constraints) => Watch(() {
+                        final controller = _controller.value;
+                        if (controller == null) {
+                          return Center(
+                              child: OImage.oNetwork(
+                            widget.metaEiga.value.poster!,
+                            sourceId: widget.service.uid,
+                            fit: BoxFit.cover,
+                          ));
+                        }
 
-                      final qualityCode = _qualityCode.value;
-                      final aspectRatio = _aspectRatio.value;
+                        final maxWidth = _fullscreen.value
+                            ? 100.w(context)
+                            : constraints.biggest.width;
+                        final maxHeight = _fullscreen.value
+                            ? 100.h(context)
+                            : (maxWidth / widget.aspectRatio);
 
-                      timerCounter?.cancel();
-                      if (counter.value < 10) {
-                        timerCounter = Timer(Duration(milliseconds: 222), () {
-                          timerCounter = null;
-                          counter.value++;
-                        });
-                      }
+                        final qualityCode = _qualityCode.value;
+                        final aspectRatio = _aspectRatio.value;
 
-                      double width = maxWidth;
-                      double height = width /
-                          aspectRatio; // Calculate height based on the aspect ratio
+                        double width = maxWidth;
+                        double height = width /
+                            aspectRatio; // Calculate height based on the aspect ratio
 
-                      // If the calculated height exceeds the maximum allowed height,
-                      // adjust dimensions to use maxHeight
-                      if (height > maxHeight) {
-                        height = maxHeight;
-                        width = height *
-                            aspectRatio; // Recalculate width accordingly
-                      }
+                        // If the calculated height exceeds the maximum allowed height,
+                        // adjust dimensions to use maxHeight
+                        if (height > maxHeight) {
+                          height = maxHeight;
+                          width = height *
+                              aspectRatio; // Recalculate width accordingly
+                        }
 
-                      return SubtitleWrapper(
-                        enabled: qualityCode != null,
-                        videoPlayerController: controller,
-                        subtitleController: subtitleController,
-                        subtitleStyle: SubtitleStyle(
-                          textColor: Colors.white,
-                          hasBorder: true,
-                        ),
-                        videoChild: Center(
-                            child: FractionallySizedBox(
-                          widthFactor: width / maxWidth,
-                          heightFactor: height / maxHeight,
-                          child: VideoPlayer(controller),
-                        )),
-                      );
-                    }),
-                  )),
+                        return SubtitleWrapper(
+                          enabled: qualityCode != null,
+                          videoPlayerController: controller,
+                          subtitleController: subtitleController,
+                          subtitleStyle: SubtitleStyle(
+                            textColor: Colors.white,
+                            hasBorder: true,
+                          ),
+                          videoChild: Center(
+                              child: FractionallySizedBox(
+                            widthFactor: width / maxWidth,
+                            heightFactor: height / maxHeight,
+                            child: VideoPlayer(controller),
+                          )),
+                        );
+                      }),
+                    );
+                  })),
         ),
         Watch(() {
           final child = _showControls.value || _error.value != null


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed video player size issue in fullscreen mode.

- Replaced `DelayedWidget` with `StatefulBuilder` for dynamic updates.

- Improved layout recalculations for fullscreen transitions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>player_eiga.dart</strong><dd><code>Refactored video player layout for fullscreen handling</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/screens/home_eiga/player_eiga.dart

<li>Replaced <code>DelayedWidget</code> with <code>StatefulBuilder</code> for dynamic state updates.<br> <li> Adjusted logic for recalculating video dimensions in fullscreen mode.<br> <li> Added <code>setState2</code> to ensure UI updates dynamically during transitions.<br> <li> Improved handling of aspect ratio and size constraints.


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/14/files#diff-de656e6fe86adbac61295bc1857da79484f71f42317a8f2431d0dcb35776d760">+62/-60</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the video player's state handling for more reliable and smooth playback while maintaining consistent subtitle display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->