### PR TITLE
8 history online for hoyomi

### DIFF
--- a/lib/core_services/comic/services/truyengg/main.dart
+++ b/lib/core_services/comic/services/truyengg/main.dart
@@ -75,8 +75,6 @@ class TruyenGGService extends ABComicService with AuthMixin, ComicAuthMixin {
       return 'type_comic=1; $cookie';
     },
   );
-  @override
-  final authInit = AuthInit(signInUrl: (service) => '${service.baseUrl}/');
 
   final Map<String, String> _comicCachedStore = {};
   final Map<String, String> _episodeIdStore = {};

--- a/lib/core_services/eiga/mixin/eiga_auth_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_auth_mixin.dart
@@ -1,6 +1,8 @@
 import 'package:hoyomi/core_services/mixin/auth_mixin.dart';
 
-mixin EigaAuthMixin on AuthMixin {
+mixin EigaAuthMixin implements AuthMixin {
+  @override
+  final bool $noAuth = true;
   Future<bool> isFollowed({required String eigaId});
   Future<bool> setFollow({required String eigaId, required bool value});
   Future<int> getFollowCount({required String eigaId});

--- a/lib/core_services/eiga/mixin/eiga_history_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_history_mixin.dart
@@ -1,7 +1,0 @@
-import 'package:hoyomi/core_services/eiga/interfaces/eiga.dart';
-import 'package:hoyomi/core_services/interfaces/history_item.dart';
-import 'package:hoyomi/core_services/mixin/auth_mixin.dart';
-
-mixin EigaHistoryMixin on AuthMixin {
-  Future<List<HistoryItem<Eiga>>> getWatchHistory({required int page});
-}

--- a/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
@@ -131,7 +131,8 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
           'Failed to get watch time episodes: ${response.statusCode}');
     }
 
-    final body = _WatchTimeEpisode.fromJsonList(jsonDecode(response.body) as List);
+    final body =
+        _WatchTimeEpisode.fromJsonList(jsonDecode(response.body) as List);
 
     return {
       for (final item in body)
@@ -255,7 +256,6 @@ class _WatchTime {
     );
   }
 }
-
 
 class _WatchTimeEpisode {
   final num cur;

--- a/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
@@ -35,8 +35,11 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
 
     final response = await get(
         Uri.parse(_baseApiGeneral!).resolve(
-            '/eiga/get-watch-time?eiga_text_id=$eigaId&chap_id=${episode.episodeId}&sourceId=$uid'),
-        headers: {'Authorization': 'Bearer ${idToken.token}'});
+            '/api/eiga/get-watch-time?eiga_text_id=$eigaId&chap_id=${episode.episodeId}&sourceId=$uid'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ${idToken.token}'
+        });
 
     if (response.statusCode != 200) {
       throw Exception('Failed to get watch time: ${response.statusCode}');
@@ -63,8 +66,11 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
 
     final response = await get(
         Uri.parse(_baseApiGeneral!).resolve(
-            '/eiga/get-watch-time-episodes?eiga_text_id=$eigaId&sourceId=$uid'),
-        headers: {'Authorization': 'Bearer ${idToken.token}'});
+            '/api/eiga/get-watch-time-episodes?eiga_text_id=$eigaId&sourceId=$uid'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ${idToken.token}'
+        });
 
     if (response.statusCode != 200) {
       throw Exception('Failed to get watch time: ${response.statusCode}');
@@ -98,22 +104,23 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
     final idToken = await user.getIdTokenResult();
 
     final response = await post(
-        Uri.parse(_baseApiGeneral!).resolve('/eiga/set-watch-time'),
+        Uri.parse(_baseApiGeneral!).resolve('/api/eiga/set-watch-time'),
         headers: {
+          'Content-Type': 'application/json',
           'Authorization': 'Bearer ${idToken.token}'
         },
-        body: <String, String>{
+        body: jsonEncode({
           'sourceId': uid,
           // data
           'name': metaEiga.name,
           'poster': metaEiga.poster?.src ?? metaEiga.image.src,
           'eiga_text_id': eigaId,
           'season_name': season.name,
-          'cur': watchTime.position.inMilliseconds.toString(),
-          'dur': watchTime.duration.inMilliseconds.toString(),
+          'cur': watchTime.position.inMilliseconds / 1e3,
+          'dur': watchTime.duration.inMilliseconds / 1e3,
           'episode_name': episode.name,
           'episode_id': episode.episodeId,
-        });
+        }));
 
     if (response.statusCode != 200) {
       throw Exception('Failed to get watch time: ${response.statusCode}');

--- a/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
@@ -9,7 +9,8 @@ import 'package:http/http.dart';
 import '../interfaces/main.dart';
 import 'eiga_watch_time_mixin.dart';
 
-final _baseApiGeneral = dotenv.env['BASE_API_GENERAL'];
+mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
+  final String? _baseApiGeneral = dotenv.env['BASE_API_GENERAL'];
 mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
   /// General watch time support but service not auth
   @override

--- a/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
@@ -16,7 +16,7 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
   @override
   final bool $noAuth = true;
   @override
-  getUser({required String cookie}) {
+  Future<User> getUser({required String cookie}) {
     throw UnimplementedError();
   }
 

--- a/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:hoyomi/core_services/exception/user_not_found_exception.dart';
 import 'package:hoyomi/core_services/service.dart';
+import 'package:hoyomi/utils/authentication.dart';
 import 'package:http/http.dart';
 
 import '../interfaces/main.dart';
@@ -28,7 +28,7 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
   }) async {
     assert(_baseApiGeneral != null, 'BASE_API_GENERAL is not set');
 
-    final user = FirebaseAuth.instance.currentUser;
+    final user = await Authentication.instance.getUserAsync();
     if (user == null) throw UserNotFoundException();
 
     final idToken = await user.getIdTokenResult();
@@ -59,7 +59,7 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
   }) async {
     assert(_baseApiGeneral != null, 'BASE_API_GENERAL is not set');
 
-    final user = FirebaseAuth.instance.currentUser;
+    final user = await Authentication.instance.getUserAsync();
     if (user == null) throw UserNotFoundException();
 
     final idToken = await user.getIdTokenResult();
@@ -98,7 +98,7 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
   }) async {
     assert(_baseApiGeneral != null, 'BASE_API_GENERAL is not set');
 
-    final user = FirebaseAuth.instance.currentUser;
+    final user = await Authentication.instance.getUserAsync();
     if (user == null) throw UserNotFoundException();
 
     final idToken = await user.getIdTokenResult();

--- a/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
@@ -11,7 +11,7 @@ import 'eiga_watch_time_mixin.dart';
 
 mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
   final String? _baseApiGeneral = dotenv.env['BASE_API_GENERAL'];
-mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
+
   /// General watch time support but service not auth
   @override
   final bool $noAuth = true;

--- a/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
@@ -20,6 +20,56 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
   }
 
   @override
+  Future<List<HistoryItem<Eiga>>> getWatchHistory({required int page}) async {
+    assert(_baseApiGeneral != null, 'BASE_API_GENERAL is not set');
+
+    final user = await Authentication.instance.getUserAsync();
+    if (user == null) throw UserNotFoundException();
+
+    final idToken = await user.getIdTokenResult();
+
+    final response = await get(
+        Uri.parse(_baseApiGeneral!)
+            .resolve('/api/eiga/get-watch-history?sourceId=$uid&page=$page'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer ${idToken.token}'
+        });
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to get histories: ${response.statusCode}');
+    }
+
+    final body = jsonDecode(response.body) as List;
+
+    return body
+        .map((raw) {
+          final history = _WatchHistory.fromJson(raw);
+          if (history.watchName == null) return null;
+
+          return HistoryItem<Eiga>(
+            item: Eiga(
+              name: history.name,
+              eigaId: history.eigaTextId,
+              originalName: history.seasonName,
+              image: OImage(src: history.poster),
+            ),
+            watchUpdatedAt: history.createdAt,
+            lastEpisode: EigaEpisode(
+                name: history.watchName ?? '',
+                episodeId: history.watchId ?? ''),
+            watchTime: WatchTime(
+              position: Duration(seconds: history.watchCur?.round() ?? 0),
+              duration: Duration(seconds: history.watchDur?.round() ?? 0),
+            ),
+          );
+        })
+        .where((item) => item != null)
+        .cast<HistoryItem<Eiga>>()
+        .toList();
+  }
+
+  @override
   Future<WatchTime> getWatchTime({
     required String eigaId,
     required EigaEpisode episode,
@@ -46,9 +96,12 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
     }
 
     final body = jsonDecode(response.body);
+    if (body == null) throw Exception('No watch time found');
+
+    final history = _WatchTime.fromJson(body);
     return WatchTime(
-      position: Duration(seconds: (body['cur'] as num).round()),
-      duration: Duration(seconds: (body['dur'] as num).round()),
+      position: Duration(seconds: history.cur.round()),
+      duration: Duration(seconds: history.dur.round()),
     );
   }
 
@@ -73,16 +126,17 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
         });
 
     if (response.statusCode != 200) {
-      throw Exception('Failed to get watch time: ${response.statusCode}');
+      throw Exception(
+          'Failed to get watch time episodes: ${response.statusCode}');
     }
 
-    final body = jsonDecode(response.body) as List;
+    final body = _WatchTimeEpisode.fromJsonList(jsonDecode(response.body) as List);
 
     return {
       for (final item in body)
-        item['chapId'].toString(): WatchTime(
-          position: Duration(seconds: (item['cur'] as num).round()),
-          duration: Duration(seconds: (item['dur'] as num).round()),
+        item.chapId: WatchTime(
+          position: Duration(seconds: item.cur.round()),
+          duration: Duration(seconds: item.dur.round()),
         )
     };
   }
@@ -123,7 +177,114 @@ mixin EigaWatchTimeGeneralMixin on Service implements EigaWatchTimeMixin {
         }));
 
     if (response.statusCode != 200) {
-      throw Exception('Failed to get watch time: ${response.statusCode}');
+      throw Exception('Failed to set watch time: ${response.statusCode}');
     }
+  }
+}
+
+/// ============== models ================
+class _WatchHistory {
+  final String sourceId;
+  final String eigaTextId;
+  final String name;
+  final String poster;
+  final String seasonName;
+  final DateTime createdAt;
+  final DateTime? watchUpdatedAt;
+  final String? watchName;
+  final String? watchId;
+  final num? watchCur;
+  final num? watchDur;
+
+  _WatchHistory({
+    required this.sourceId,
+    required this.eigaTextId,
+    required this.name,
+    required this.poster,
+    required this.seasonName,
+    required this.createdAt,
+    this.watchUpdatedAt,
+    this.watchName,
+    this.watchId,
+    this.watchCur,
+    this.watchDur,
+  });
+
+  factory _WatchHistory.fromJson(Map<String, dynamic> json) {
+    return _WatchHistory(
+      sourceId: json['sourceId'] as String,
+      eigaTextId: json['eigaTextId'] as String,
+      name: json['name'] as String,
+      poster: json['poster'] as String,
+      seasonName: json['seasonName'] as String,
+      createdAt: DateTime.parse(json['createdAt']),
+      watchUpdatedAt: json['watchUpdatedAt'] != null
+          ? DateTime.parse(json['watchUpdatedAt'])
+          : null,
+      watchName: json['watchName'] as String?,
+      watchId: json['watchId'] as String?,
+      watchCur: json['watchCur'] as num?,
+      watchDur: json['watchDur'] as num?,
+    );
+  }
+}
+
+class _WatchTime {
+  final num cur;
+  final num dur;
+  final String name;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  _WatchTime({
+    required this.cur,
+    required this.dur,
+    required this.name,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  factory _WatchTime.fromJson(Map<String, dynamic> json) {
+    return _WatchTime(
+      cur: json['cur'] as num,
+      dur: json['dur'] as num,
+      name: json['name'] as String,
+      createdAt: DateTime.parse(json['createdAt']),
+      updatedAt: DateTime.parse(json['updatedAt']),
+    );
+  }
+}
+
+
+class _WatchTimeEpisode {
+  final num cur;
+  final num dur;
+  final String name;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final String chapId;
+
+  _WatchTimeEpisode({
+    required this.cur,
+    required this.dur,
+    required this.name,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.chapId,
+  });
+
+  factory _WatchTimeEpisode.fromJson(Map<String, dynamic> json) {
+    return _WatchTimeEpisode(
+      cur: json['cur'] as num,
+      dur: json['dur'] as num,
+      name: json['name'] as String,
+      createdAt: DateTime.parse(json['createdAt']),
+      updatedAt: DateTime.parse(json['updatedAt']),
+      chapId: json['chapId'] as String,
+    );
+  }
+
+  static List<_WatchTimeEpisode> fromJsonList(List<dynamic> jsonList) {
+    return jsonList.map((json) => _WatchTimeEpisode.fromJson(json)).toList();
   }
 }

--- a/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:hoyomi/core_services/exception/user_not_found_exception.dart';
+import 'package:http/http.dart';
+
+import '../interfaces/main.dart';
+import 'eiga_watch_time_mixin.dart';
+
+final _baseApiGeneral = dotenv.env['BASE_API_GENERAL'];
+mixin EigaWatchTimeGeneralMixin implements EigaWatchTimeMixin {
+  @override
+  Future<WatchTime> getWatchTime({
+    required String eigaId,
+    required EigaEpisode episode,
+    required int episodeIndex,
+    required MetaEiga metaEiga,
+  }) async {
+    assert(_baseApiGeneral != null, 'BASE_API_GENERAL is not set');
+
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) throw UserNotFoundException();
+
+    final idToken = await user.getIdTokenResult();
+
+    final response = await get(
+        Uri.parse(_baseApiGeneral!).resolve(
+            '/eiga/get-watch-time?eiga_text_id=$eigaId&chap_id=${episode.episodeId}'),
+        headers: {'Authorization': 'Bearer ${idToken.token}'});
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to get watch time: ${response.statusCode}');
+    }
+
+    final body = jsonDecode(response.body);
+    return WatchTime(
+      position: Duration(seconds: (body['cur'] as num).round()),
+      duration: Duration(seconds: (body['dur'] as num).round()),
+    );
+  }
+
+  @override
+  Future<Map<String, WatchTime>> getWatchTimeEpisodes({
+    required String eigaId,
+    required List<EigaEpisode> episodes,
+  }) async {
+    assert(_baseApiGeneral != null, 'BASE_API_GENERAL is not set');
+
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) throw UserNotFoundException();
+
+    final idToken = await user.getIdTokenResult();
+
+    final response = await get(
+        Uri.parse(_baseApiGeneral!)
+            .resolve('/eiga/get-watch-time-episodes?eiga_text_id=$eigaId'),
+        headers: {'Authorization': 'Bearer ${idToken.token}'});
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to get watch time: ${response.statusCode}');
+    }
+
+    final body = jsonDecode(response.body) as List;
+
+    return {
+      for (final item in body)
+        item['chapId'].toString(): WatchTime(
+          position: Duration(seconds: (item['cur'] as num).round()),
+          duration: Duration(seconds: (item['dur'] as num).round()),
+        )
+    };
+  }
+
+  @override
+  Future<void> setWatchTime({
+    required String eigaId,
+    required EigaEpisode episode,
+    required int episodeIndex,
+    required MetaEiga metaEiga,
+    required Season season,
+    required WatchTime watchTime,
+  }) async {
+    assert(_baseApiGeneral != null, 'BASE_API_GENERAL is not set');
+
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) throw UserNotFoundException();
+
+    final idToken = await user.getIdTokenResult();
+
+    final response = await post(
+        Uri.parse(_baseApiGeneral!).resolve('/eiga/set-watch-time'),
+        headers: {
+          'Authorization': 'Bearer ${idToken.token}'
+        },
+        body: <String, String>{
+          'name': metaEiga.name,
+          //         poster: z.string().min(1),
+          // eiga_text_id: z.string().min(1),
+          // season_name: z.string().min(1),
+          // cur: z.number(),
+          // dur: z.number(),
+          // episode_name: z.string(),
+          // episode_id: z.string()
+
+          'poster': metaEiga.poster?.src ?? metaEiga.image.src,
+          'eiga_text_id': eigaId,
+          'season_name': season.name,
+          'cur': watchTime.position.inMilliseconds.toString(),
+          'dur': watchTime.duration.inMilliseconds.toString(),
+          'episode_name': episode.name,
+          'episode_id': episode.episodeId,
+        });
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to get watch time: ${response.statusCode}');
+    }
+  }
+}

--- a/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart
@@ -212,19 +212,19 @@ class _WatchHistory {
 
   factory _WatchHistory.fromJson(Map<String, dynamic> json) {
     return _WatchHistory(
-      sourceId: json['sourceId'] as String,
-      eigaTextId: json['eigaTextId'] as String,
+      sourceId: json['source_id'] as String,
+      eigaTextId: json['eiga_text_id'] as String,
       name: json['name'] as String,
       poster: json['poster'] as String,
-      seasonName: json['seasonName'] as String,
-      createdAt: DateTime.parse(json['createdAt']),
-      watchUpdatedAt: json['watchUpdatedAt'] != null
-          ? DateTime.parse(json['watchUpdatedAt'])
+      seasonName: json['season_name'] as String,
+      createdAt: DateTime.parse(json['created_at']),
+      watchUpdatedAt: json['watch_updated_at'] != null
+          ? DateTime.parse(json['watch_updated_at'])
           : null,
-      watchName: json['watchName'] as String?,
-      watchId: json['watchId'] as String?,
-      watchCur: json['watchCur'] as num?,
-      watchDur: json['watchDur'] as num?,
+      watchName: json['watch_name'] as String?,
+      watchId: json['watch_id'] as String?,
+      watchCur: json['watch_cur'] as num?,
+      watchDur: json['watch_dur'] as num?,
     );
   }
 }

--- a/lib/core_services/eiga/mixin/eiga_watch_time_mixin.dart
+++ b/lib/core_services/eiga/mixin/eiga_watch_time_mixin.dart
@@ -1,9 +1,9 @@
-import 'package:hoyomi/core_services/eiga/interfaces/eiga_episode.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/meta_eiga.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/watch_time.dart';
+import 'package:hoyomi/core_services/eiga/interfaces/main.dart';
 import 'package:hoyomi/core_services/mixin/auth_mixin.dart';
 
 mixin EigaWatchTimeMixin on AuthMixin {
+  Future<List<HistoryItem<Eiga>>> getWatchHistory({required int page});
+
   Future<WatchTime> getWatchTime({
     required String eigaId,
     required EigaEpisode episode,

--- a/lib/core_services/eiga/services/animevietsub/main.dart
+++ b/lib/core_services/eiga/services/animevietsub/main.dart
@@ -101,11 +101,6 @@ class AnimeVietsubService extends ABEigaService
     faviconUrl: OImage(src: '/favicon.ico'),
     rootUrl: 'https://$hostCUrl',
   );
-  @override
-  final authInit = AuthInit(
-    signInUrl: (service) =>
-        "${service.baseUrl}/account/login/?_fxRef=${service.baseUrl}/",
-  );
 
   final String _apiOpEnd = "https://opend-9animetv.animevsub.eu.org";
   final String _apiThumb = "https://sk-hianime.animevsub.eu.org";

--- a/lib/core_services/eiga/services/animevietsub/main.dart
+++ b/lib/core_services/eiga/services/animevietsub/main.dart
@@ -64,11 +64,7 @@ mixin _SupabaseRPC {
 }
 
 class AnimeVietsubService extends ABEigaService
-    with
-        EigaAuthMixin,
-        EigaWatchTimeMixin,
-        EigaFollowMixin,
-        _SupabaseRPC {
+    with EigaAuthMixin, EigaWatchTimeMixin, EigaFollowMixin, _SupabaseRPC {
   final hostCUrl = "animevietsub.lol";
   @override
   late final init = ServiceInit(

--- a/lib/core_services/eiga/services/animevietsub/main.dart
+++ b/lib/core_services/eiga/services/animevietsub/main.dart
@@ -3,35 +3,12 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/watch_time.dart';
-import 'package:hoyomi/core_services/eiga/mixin/eiga_auth_mixin.dart';
 import 'package:hoyomi/core_services/eiga/ab_eiga_service.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/eiga_home.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/eiga_category.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/eiga_episode.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/eiga_episodes.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/opening_ending.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/source_content.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/source_video.dart';
+import 'package:hoyomi/core_services/eiga/interfaces/main.dart';
+import 'package:hoyomi/core_services/eiga/mixin/eiga_auth_mixin.dart';
 import 'package:hoyomi/core_services/eiga/mixin/eiga_follow_mixin.dart';
-import 'package:hoyomi/core_services/eiga/mixin/eiga_history_mixin.dart';
 import 'package:hoyomi/core_services/eiga/mixin/eiga_watch_time_mixin.dart';
 import 'package:hoyomi/core_services/exception/user_not_found_exception.dart';
-import 'package:hoyomi/core_services/interfaces/carousel.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/carousel_item.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/eiga.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/home_eiga_category.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/eiga_param.dart';
-import 'package:hoyomi/core_services/eiga/interfaces/meta_eiga.dart';
-import 'package:hoyomi/core_services/interfaces/filter.dart';
-import 'package:hoyomi/core_services/interfaces/follow_item.dart';
-import 'package:hoyomi/core_services/interfaces/genre.dart';
-import 'package:hoyomi/core_services/interfaces/history_item.dart';
-import 'package:hoyomi/core_services/interfaces/o_image.dart';
-import 'package:hoyomi/core_services/interfaces/paginate.dart';
-import 'package:hoyomi/core_services/interfaces/user.dart';
-import 'package:hoyomi/core_services/interfaces/vtt.dart';
-import 'package:hoyomi/core_services/mixin/auth_mixin.dart';
 import 'package:html/dom.dart';
 
 import 'package:crypto/crypto.dart';
@@ -88,10 +65,8 @@ mixin _SupabaseRPC {
 
 class AnimeVietsubService extends ABEigaService
     with
-        AuthMixin,
         EigaAuthMixin,
         EigaWatchTimeMixin,
-        EigaHistoryMixin,
         EigaFollowMixin,
         _SupabaseRPC {
   final hostCUrl = "animevietsub.lol";

--- a/lib/core_services/eiga/services/kkphim/main.dart
+++ b/lib/core_services/eiga/services/kkphim/main.dart
@@ -9,10 +9,11 @@ import 'package:flutter_hls_parser/flutter_hls_parser.dart';
 import 'package:get/get.dart';
 import 'package:hoyomi/core_services/eiga/ab_eiga_service.dart';
 import 'package:hoyomi/core_services/eiga/interfaces/main.dart';
+import 'package:hoyomi/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart';
 
 import 'package:mediaquery_sizer/mediaquery_sizer.dart';
 
-class KKPhimService extends ABEigaService
+class KKPhimService extends ABEigaService with EigaWatchTimeGeneralMixin
 // with
 // EigaWatchTimeMixin,
 // EigaHistoryMixin,

--- a/lib/core_services/eiga/services/nguonc/main.dart
+++ b/lib/core_services/eiga/services/nguonc/main.dart
@@ -7,10 +7,11 @@ import 'dart:math';
 import 'package:get/get.dart';
 import 'package:hoyomi/core_services/eiga/ab_eiga_service.dart';
 import 'package:hoyomi/core_services/eiga/interfaces/main.dart';
+import 'package:hoyomi/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart';
 
 import 'package:mediaquery_sizer/mediaquery_sizer.dart';
 
-class NguonCService extends ABEigaService
+class NguonCService extends ABEigaService with EigaWatchTimeGeneralMixin
 // with
 // EigaWatchTimeMixin,
 // EigaHistoryMixin,

--- a/lib/core_services/eiga/services/ophim/main.dart
+++ b/lib/core_services/eiga/services/ophim/main.dart
@@ -9,10 +9,11 @@ import 'package:get/get.dart';
 import 'package:flutter_hls_parser/flutter_hls_parser.dart';
 import 'package:hoyomi/core_services/eiga/ab_eiga_service.dart';
 import 'package:hoyomi/core_services/eiga/interfaces/main.dart';
+import 'package:hoyomi/core_services/eiga/mixin/eiga_watch_time_general_mixin.dart';
 
 import 'package:mediaquery_sizer/mediaquery_sizer.dart';
 
-class OPhimService extends ABEigaService
+class OPhimService extends ABEigaService with EigaWatchTimeGeneralMixin
 // with
 // EigaWatchTimeMixin,
 // EigaHistoryMixin,
@@ -442,6 +443,16 @@ class OPhimService extends ABEigaService
       // /_next/data/YjU3ELa3ICaBELMtMHUHj/tim-kiem.json?keyword=%C4%91%E1%BA%A1o+l%C3%A0m+ch%E1%BB%93ng+%C4%91%E1%BA%A3m
       filters: filters,
     );
+  }
+
+  @override
+  // TODO: implement authInit
+  AuthInit get authInit => throw UnimplementedError();
+
+  @override
+  Future<User> getUser({required String cookie}) {
+    // TODO: implement getUser
+    throw UnimplementedError();
   }
 }
 

--- a/lib/core_services/eiga/services/ophim/main.dart
+++ b/lib/core_services/eiga/services/ophim/main.dart
@@ -444,16 +444,6 @@ class OPhimService extends ABEigaService with EigaWatchTimeGeneralMixin
       filters: filters,
     );
   }
-
-  @override
-  // TODO: implement authInit
-  AuthInit get authInit => throw UnimplementedError();
-
-  @override
-  Future<User> getUser({required String cookie}) {
-    // TODO: implement getUser
-    throw UnimplementedError();
-  }
 }
 
 /// ======================= utils =========================

--- a/lib/core_services/mixin/auth_mixin.dart
+++ b/lib/core_services/mixin/auth_mixin.dart
@@ -1,14 +1,10 @@
-import 'package:hoyomi/core_services/service.dart';
-
 import '../interfaces/user.dart';
 
-class AuthInit {
-  final String Function(Service service) signInUrl;
-
-  AuthInit({required this.signInUrl});
-}
-
 mixin AuthMixin {
-  AuthInit get authInit;
+  static bool support(Object $mixin) {
+    return $mixin is AuthMixin && $mixin.$noAuth == false;
+  }
+
+  final bool $noAuth = false;
   Future<User> getUser({required String cookie});
 }

--- a/lib/pages/details_comic/[sourceId]/[comicId].page.dart
+++ b/lib/pages/details_comic/[sourceId]/[comicId].page.dart
@@ -128,7 +128,7 @@ class _DetailsComicState extends State<DetailsComic>
                 child: Text(_title),
               )),
           actions: [
-            if (_service is ComicAuthMixin && _service is AuthMixin)
+            if (_service is ComicAuthMixin && AuthMixin.support(_service))
               _AvatarUser(service: _service),
             IconButtonShare(),
             IconButtonFollow(
@@ -433,6 +433,7 @@ class _DetailsComicState extends State<DetailsComic>
 
         // Comment
         if (_service is ComicAuthMixin &&
+            !(_service as AuthMixin).$noAuth &&
             (_service as ComicAuthMixin).getComments != null)
           Padding(
             padding: EdgeInsets.only(bottom: 16),
@@ -749,7 +750,8 @@ class _ButtonLikeState extends State<_ButtonLike> {
     super.initState();
     _likes = widget.comic.likes;
 
-    if (widget.service is ComicAuthMixin) {
+    if (widget.service is ComicAuthMixin &&
+        !(widget.service as AuthMixin).$noAuth) {
       (widget.service as ComicAuthMixin)
           .isLiked(comicId: widget.comicId)
           .then((liked) {
@@ -787,7 +789,10 @@ class _ButtonLikeState extends State<_ButtonLike> {
   @override
   Widget build(BuildContext context) {
     return InkWell(
-      onTap: (widget.service is ComicAuthMixin) ? _onTap : null,
+      onTap: (widget.service is ComicAuthMixin &&
+              !(widget.service as AuthMixin).$noAuth)
+          ? _onTap
+          : null,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(30.0),
         child: Padding(

--- a/lib/pages/details_eiga/[sourceId]/[eigaId].page.dart
+++ b/lib/pages/details_eiga/[sourceId]/[eigaId].page.dart
@@ -286,7 +286,9 @@ class _DetailsEigaPageState extends State<DetailsEigaPage>
             watchTime: watchTime,
           )
               .catchError((error) {
-            if (error is! UserNotFoundException) debugPrint('Error: $error (${StackTrace.current})');
+            if (error is! UserNotFoundException) {
+              debugPrint('Error: $error (${StackTrace.current})');
+            }
           });
         }
       },

--- a/lib/pages/details_eiga/[sourceId]/[eigaId].page.dart
+++ b/lib/pages/details_eiga/[sourceId]/[eigaId].page.dart
@@ -12,6 +12,7 @@ import 'package:hoyomi/core_services/eiga/interfaces/eiga.dart';
 import 'package:hoyomi/core_services/eiga/interfaces/watch_time.dart';
 import 'package:hoyomi/core_services/eiga/interfaces/watch_time_data.dart';
 import 'package:hoyomi/core_services/eiga/mixin/eiga_watch_time_mixin.dart';
+import 'package:hoyomi/core_services/exception/user_not_found_exception.dart';
 import 'package:hoyomi/core_services/interfaces/o_image.dart';
 import 'package:hoyomi/utils/cache_remember.dart';
 import 'package:hoyomi/widgets/eiga/button_follow_eiga.dart';
@@ -275,14 +276,18 @@ class _DetailsEigaPageState extends State<DetailsEigaPage>
               ),
             ),
           );
-          (_service as EigaWatchTimeMixin).setWatchTime(
+          (_service as EigaWatchTimeMixin)
+              .setWatchTime(
             eigaId: eigaId,
             episode: _episode.value!,
             episodeIndex: _episodeIndex.value!,
             metaEiga: _metaEiga.value,
             season: _currentSeason.value!,
             watchTime: watchTime,
-          );
+          )
+              .catchError((error) {
+            if (error is! UserNotFoundException) debugPrint('Error: $error (${StackTrace.current})');
+          });
         }
       },
       aspectRatio: _aspectRatio,

--- a/lib/pages/library/history/eiga/[sourceId].page.dart
+++ b/lib/pages/library/history/eiga/[sourceId].page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart' hide TimeOfDay;
 import 'package:hoyomi/core_services/eiga/interfaces/eiga.dart';
-import 'package:hoyomi/core_services/eiga/mixin/eiga_history_mixin.dart';
+import 'package:hoyomi/core_services/eiga/mixin/eiga_watch_time_mixin.dart';
 import 'package:hoyomi/core_services/interfaces/history_item.dart';
 import 'package:hoyomi/core_services/main.dart';
 import 'package:hoyomi/core_services/service.dart';
@@ -20,11 +20,11 @@ class HistoryEigaPage extends StatefulWidget {
 
 class _HistoryEigaPageState extends State<HistoryEigaPage> {
   int _pageKey = 2;
-  late final EigaHistoryMixin _service;
+  late final EigaWatchTimeMixin _service;
 
   @override
   void initState() {
-    _service = getEigaService(widget.sourceId) as EigaHistoryMixin;
+    _service = getEigaService(widget.sourceId) as EigaWatchTimeMixin;
     super.initState();
   }
 

--- a/lib/pages/library/library_page.dart
+++ b/lib/pages/library/library_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hoyomi/core_services/eiga/mixin/eiga_follow_mixin.dart';
-import 'package:hoyomi/core_services/eiga/mixin/eiga_history_mixin.dart';
+import 'package:hoyomi/core_services/eiga/mixin/eiga_watch_time_mixin.dart';
 import 'package:hoyomi/core_services/main.dart';
 import 'package:hoyomi/core_services/service.dart';
 import 'package:hoyomi/widgets/library/follow/eiga/horizontal_eiga_follow_list.dart';
@@ -84,7 +84,7 @@ class _TabViewState extends State<_TabView> with AutomaticKeepAliveClientMixin {
   Widget build(BuildContext context) {
     super.build(context);
 
-    if (_service is! EigaHistoryMixin && _service is! EigaFollowMixin) {
+    if (_service is! EigaWatchTimeMixin && _service is! EigaFollowMixin) {
       return Center(child: Text('This service not support history or follow'));
     }
 
@@ -97,7 +97,7 @@ class _TabViewState extends State<_TabView> with AutomaticKeepAliveClientMixin {
         return ListView(
           padding: EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
           children: [
-            if (_service is EigaHistoryMixin)
+            if (_service is EigaWatchTimeMixin)
               HorizontalEigaHistoryList(sourceId: widget.sourceId),
             if (_service is EigaFollowMixin)
               HorizontalEigaFollowList(sourceId: widget.sourceId),

--- a/lib/screens/details_eiga/list_episodes.dart
+++ b/lib/screens/details_eiga/list_episodes.dart
@@ -6,6 +6,7 @@ import 'package:hoyomi/core_services/eiga/interfaces/eiga_episode.dart';
 import 'package:hoyomi/core_services/eiga/interfaces/eiga_episodes.dart';
 import 'package:hoyomi/core_services/eiga/interfaces/meta_eiga.dart';
 import 'package:hoyomi/core_services/eiga/interfaces/watch_time.dart';
+import 'package:hoyomi/core_services/exception/user_not_found_exception.dart';
 import 'package:hoyomi/core_services/interfaces/o_image.dart';
 import 'package:hoyomi/core_services/service.dart';
 import 'package:hoyomi/pages/details_eiga/[sourceId]/[eigaId].page.dart';
@@ -64,6 +65,8 @@ class _ListEpisodesState extends State<ListEpisodes>
 
       widget.getWatchTimeEpisodes(episodes).then((watchTimes) {
         if (mounted) _watchTimeEpisodes.value = watchTimes;
+      }).catchError((error) {
+        if (error is! UserNotFoundException) debugPrint('Error: $error (${StackTrace.current})');
       });
 
       if (widget.eager) {

--- a/lib/screens/details_eiga/list_episodes.dart
+++ b/lib/screens/details_eiga/list_episodes.dart
@@ -66,7 +66,8 @@ class _ListEpisodesState extends State<ListEpisodes>
       widget.getWatchTimeEpisodes(episodes).then((watchTimes) {
         if (mounted) _watchTimeEpisodes.value = watchTimes;
       }).catchError((error) {
-        if (error is! UserNotFoundException) debugPrint('Error: $error (${StackTrace.current})');
+        if (error is! UserNotFoundException)
+          debugPrint('Error: $error (${StackTrace.current})');
       });
 
       if (widget.eager) {

--- a/lib/screens/home_eiga/player_eiga.dart
+++ b/lib/screens/home_eiga/player_eiga.dart
@@ -17,6 +17,7 @@ import 'package:hoyomi/core_services/eiga/interfaces/opening_ending.dart';
 import 'package:hoyomi/core_services/eiga/interfaces/source_content.dart';
 import 'package:hoyomi/core_services/eiga/interfaces/watch_time_data.dart';
 import 'package:hoyomi/core_services/eiga/mixin/eiga_watch_time_mixin.dart';
+import 'package:hoyomi/core_services/exception/user_not_found_exception.dart';
 import 'package:hoyomi/core_services/interfaces/o_image.dart';
 import 'package:hoyomi/core_services/interfaces/vtt.dart';
 import 'package:hoyomi/apis/show_snack_bar.dart';
@@ -238,7 +239,9 @@ class _PlayerEigaState extends State<PlayerEiga>
                   watchTime: data,
                 ))
             .catchError((error) {
-          debugPrint('Error: $error (${StackTrace.current})');
+          if (error is! UserNotFoundException) {
+            debugPrint('Error: $error (${StackTrace.current})');
+          }
 
           return WatchTimeData(
             eigaId: eigaId,

--- a/lib/utils/authentication.dart
+++ b/lib/utils/authentication.dart
@@ -199,7 +199,7 @@ class Authentication {
   } // =================== utils ===================
 
   void _catchFirebaseAuthException(FirebaseAuthException err) {
-    debugPrint('Error: $err');
+    debugPrint('Error: $err (${StackTrace.current})');
     switch (err.code) {
       case 'account-exists-with-different-credential':
         showSnackBar(
@@ -216,7 +216,7 @@ class Authentication {
   }
 
   void _catchNormalException(dynamic err) {
-    debugPrint('Error: $err');
+    debugPrint('Error: $err (${StackTrace.current})');
     showSnackBar(Text('Error occurred Auth: $err'));
   }
 }

--- a/lib/utils/authentication.dart
+++ b/lib/utils/authentication.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -175,6 +177,26 @@ class Authentication {
   }
 
   User? get currentUser => _auth.currentUser;
+
+  Future<User?> getUserAsync() {
+    final completer = Completer<User?>();
+
+    bool firstChanged = false;
+    late final StreamSubscription<User?> subscription;
+    subscription = _auth.userChanges().listen((user) {
+      if (firstChanged) {
+        subscription.cancel();
+        completer.complete(user);
+      } else {
+        firstChanged = true;
+      }
+    }, onError: (error) {
+      subscription.cancel();
+      completer.completeError(error);
+    }, onDone: () => subscription.cancel());
+
+    return completer.future;
+  } // =================== utils ===================
 
   void _catchFirebaseAuthException(FirebaseAuthException err) {
     debugPrint('Error: $err');

--- a/lib/utils/authentication.dart
+++ b/lib/utils/authentication.dart
@@ -184,7 +184,7 @@ class Authentication {
     bool firstChanged = false;
     late final StreamSubscription<User?> subscription;
     subscription = _auth.userChanges().listen((user) {
-      if (firstChanged) {
+      if (firstChanged || user != null) {
         subscription.cancel();
         completer.complete(user);
       } else {

--- a/lib/widgets/eiga/button_follow_eiga.dart
+++ b/lib/widgets/eiga/button_follow_eiga.dart
@@ -35,7 +35,8 @@ class _ButtonFollowEigaState extends State<ButtonFollowEiga> with KaeruMixin {
 
   late final UserData? _user;
 
-  bool get _supportAuth => widget.service is EigaAuthMixin;
+  bool get _supportAuth =>
+      widget.service is EigaAuthMixin && AuthMixin.support(widget.service);
 
   @override
   void initState() {

--- a/lib/widgets/library/history/eiga/horizontal_eiga_history_list.dart
+++ b/lib/widgets/library/history/eiga/horizontal_eiga_history_list.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hoyomi/core_services/eiga/interfaces/eiga.dart';
-import 'package:hoyomi/core_services/eiga/mixin/eiga_history_mixin.dart';
+import 'package:hoyomi/core_services/eiga/mixin/eiga_watch_time_mixin.dart';
 import 'package:hoyomi/core_services/interfaces/history_item.dart';
 import 'package:hoyomi/core_services/main.dart';
 import 'package:hoyomi/core_services/service.dart';
@@ -21,12 +21,12 @@ class HorizontalEigaHistoryList extends StatefulWidget {
 }
 
 class _HorizontalEigaHistoryState extends State<HorizontalEigaHistoryList> {
-  late final EigaHistoryMixin _service;
+  late final EigaWatchTimeMixin _service;
   late final Future<List<HistoryItem<Eiga>>> _historyFuture;
 
   @override
   void initState() {
-    _service = getEigaService(widget.sourceId) as EigaHistoryMixin;
+    _service = getEigaService(widget.sourceId) as EigaWatchTimeMixin;
     _historyFuture = _service.getWatchHistory(page: 1);
 
     super.initState();

--- a/lib/widgets/library/history/eiga/horizontal_eiga_history_list.dart
+++ b/lib/widgets/library/history/eiga/horizontal_eiga_history_list.dart
@@ -124,6 +124,17 @@ class _HorizontalEigaHistoryState extends State<HorizontalEigaHistoryList> {
         }
 
         final loading = snapshot.connectionState == ConnectionState.waiting;
+        if (!loading && (!snapshot.hasData || snapshot.data!.isEmpty)) {
+          return _buildContainer(
+            context,
+            title: title,
+            subtitle: '',
+            more: more,
+            builder: (viewFraction) => Center(child: Text('No data available')),
+            needSubtitle: false,
+          );
+        }
+
         final data = loading
             ? List.generate(
                 30,

--- a/lib/widgets/manager/account_service.dart
+++ b/lib/widgets/manager/account_service.dart
@@ -31,7 +31,7 @@ class _AccountServiceState extends State<AccountService> with KaeruMixin {
   });
 
   bool get _serviceAccountSupport {
-    return widget.service is AuthMixin;
+    return widget.service is AuthMixin && AuthMixin.support(widget.service);
   }
 
   @override

--- a/serverless/api/eiga/get-watch-history.ts
+++ b/serverless/api/eiga/get-watch-history.ts
@@ -1,0 +1,24 @@
+import { Hono } from "hono"
+import { z } from "npm:zod"
+import { Eiga } from "../../services/eiga.ts"
+import { useUser } from "../../logic/use-user.ts"
+import { zValidator } from "@hono/zod-validator"
+
+export const app = new Hono()
+const schema = z.object({
+  sourceId: z.string().min(1),
+  page: z.coerce.number().min(1)
+})
+app.get("/eiga/get-watch-history", zValidator("query", schema), async (c) => {
+  const params = c.req.valid("query")
+
+  const user = useUser(c)
+
+  const watchTime = await Eiga.getWatchHistory(params.sourceId, {
+    user_id: user.userId,
+    ...params,
+    limit: 30
+  })
+
+  return c.json(watchTime)
+})

--- a/serverless/api/eiga/get-watch-time-episodes.ts
+++ b/serverless/api/eiga/get-watch-time-episodes.ts
@@ -6,6 +6,7 @@ import { zValidator } from "@hono/zod-validator"
 
 export const app = new Hono()
 const schema = z.object({
+  sourceId: z.string().min(1),
   eiga_text_id: z.string().min(1)
 })
 app.get("/eiga/get-watch-time-episodes", zValidator("json", schema), async (c) => {
@@ -13,7 +14,7 @@ app.get("/eiga/get-watch-time-episodes", zValidator("json", schema), async (c) =
 
   const user = useUser(c)
 
-  const watchTime = await Eiga.getWatchTimeEpisodes({
+  const watchTime = await Eiga.getWatchTimeEpisodes(params.sourceId, {
     user_id: user.userId,
     ...params
   })

--- a/serverless/api/eiga/get-watch-time-episodes.ts
+++ b/serverless/api/eiga/get-watch-time-episodes.ts
@@ -9,8 +9,8 @@ const schema = z.object({
   sourceId: z.string().min(1),
   eiga_text_id: z.string().min(1)
 })
-app.get("/eiga/get-watch-time-episodes", zValidator("json", schema), async (c) => {
-  const params = c.req.valid("json")
+app.get("/eiga/get-watch-time-episodes", zValidator("query", schema), async (c) => {
+  const params = c.req.valid("query")
 
   const user = useUser(c)
 

--- a/serverless/api/eiga/get-watch-time.ts
+++ b/serverless/api/eiga/get-watch-time.ts
@@ -6,6 +6,7 @@ import { zValidator } from "@hono/zod-validator"
 
 export const app = new Hono()
 const schema = z.object({
+  sourceId: z.string().min(1),
   eiga_text_id: z.string().min(1),
   chap_id: z.string().min(1)
 })
@@ -14,7 +15,10 @@ app.get("/eiga/get-watch-time", zValidator("json", schema), async (c) => {
 
   const user = useUser(c)
 
-  const watchTime = await Eiga.getWatchTime({ user_id: user.userId, ...params })
+  const watchTime = await Eiga.getWatchTime(params.sourceId, {
+    user_id: user.userId,
+    ...params
+  })
 
   return c.json(watchTime)
 })

--- a/serverless/api/eiga/get-watch-time.ts
+++ b/serverless/api/eiga/get-watch-time.ts
@@ -10,8 +10,8 @@ const schema = z.object({
   eiga_text_id: z.string().min(1),
   chap_id: z.string().min(1)
 })
-app.get("/eiga/get-watch-time", zValidator("json", schema), async (c) => {
-  const params = c.req.valid("json")
+app.get("/eiga/get-watch-time", zValidator("query", schema), async (c) => {
+  const params = c.req.valid("query")
 
   const user = useUser(c)
 

--- a/serverless/api/eiga/set-watch-time.ts
+++ b/serverless/api/eiga/set-watch-time.ts
@@ -6,6 +6,7 @@ import { useUser } from "../../logic/use-user.ts"
 
 export const app = new Hono()
 const schema = z.object({
+  sourceId: z.string().min(1),
   name: z.string().min(1),
   poster: z.string().min(1),
   eiga_text_id: z.string().min(1),
@@ -20,7 +21,7 @@ app.post("/eiga/set-watch-time", zValidator("json", schema), async (c) => {
 
   const user = useUser(c)
 
-  await Eiga.setWatchTime({ user_id: user.userId, ...params })
+  await Eiga.setWatchTime(params.sourceId, { user_id: user.userId, ...params })
 
   return c.json({
     success: true

--- a/serverless/db/schema/eiga_histories.ts
+++ b/serverless/db/schema/eiga_histories.ts
@@ -9,7 +9,7 @@ import {
 import { users } from "./users.ts"
 import { eigaHistoryChapters } from "./eiga_history_chapters.ts"
 
-export const  eigaHistoriesName =  "eiga_histories"
+export const eigaHistoriesName = "eiga_histories"
 export const eigaHistories = pgTable(
   eigaHistoriesName,
   {
@@ -32,6 +32,10 @@ export const eigaHistories = pgTable(
     index("eiga_history_user_id_idx").on(table.userId),
     index("eiga_history_source_id_idx").on(table.sourceId),
     index("eiga_history_for_to_idx").on(table.forTo),
+    index("eiga_history_source_id_user_id_idx").on(
+      table.userId,
+      table.sourceId
+    ),
     index("eiga_history_user_id_source_id_eiga_text_id_idx").on(
       table.userId,
       table.sourceId,

--- a/serverless/db/schema/eiga_histories.ts
+++ b/serverless/db/schema/eiga_histories.ts
@@ -7,39 +7,39 @@ import {
   index
 } from "drizzle-orm/pg-core"
 import { users } from "./users.ts"
-import { eigaHistoryChapters } from "./eiga_history_chapters.ts";
+import { eigaHistoryChapters } from "./eiga_history_chapters.ts"
 
 export const eigaHistories = pgTable(
   "eiga_histories",
   {
     id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-    userId: integer("user_id").notNull(),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id),
+    sourceId: text("source_id").notNull(),
     eigaTextId: text("eiga_text_id").notNull(),
     name: text("name").notNull(),
     poster: text("poster").notNull(),
     seasonName: text("season_name").notNull(),
     forTo: integer("for_to"),
-    vChap: integer("v_chap"),
+    vChap: integer("v_chap").references(() => eigaHistoryChapters.id),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow()
   },
   (table) => [
     index("eiga_history_user_id_idx").on(table.userId),
+    index("eiga_history_source_id_idx").on(table.sourceId),
     index("eiga_history_for_to_idx").on(table.forTo),
-    index("eiga_history_user_id_eiga_text_id_idx").on(table.userId, table.eigaTextId),
+    index("eiga_history_user_id_source_id_eiga_text_id_idx").on(
+      table.userId,
+      table.sourceId,
+      table.eigaTextId
+    ),
     index("eiga_history_v_chap_idx").on(table.vChap),
     foreignKey({
       columns: [table.forTo],
       foreignColumns: [table.id]
-    }),
-    foreignKey({
-      columns: [table.userId],
-      foreignColumns: [users.id]
-    }),
-    foreignKey({
-      columns: [table.vChap],
-      foreignColumns: [eigaHistoryChapters.id]
     })
   ]
 )

--- a/serverless/db/schema/eiga_histories.ts
+++ b/serverless/db/schema/eiga_histories.ts
@@ -9,8 +9,9 @@ import {
 import { users } from "./users.ts"
 import { eigaHistoryChapters } from "./eiga_history_chapters.ts"
 
+export const  eigaHistoriesName =  "eiga_histories"
 export const eigaHistories = pgTable(
-  "eiga_histories",
+  eigaHistoriesName,
   {
     id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
     userId: integer("user_id")

--- a/serverless/db/schema/eiga_history_chapters.ts
+++ b/serverless/db/schema/eiga_history_chapters.ts
@@ -8,6 +8,8 @@ import {
   unique
   // foreignKey
 } from "drizzle-orm/pg-core"
+import { eigaHistories } from "./eiga_histories.ts"
+import { relations } from "drizzle-orm"
 // import { eigaHistories } from "./eiga_histories.ts"
 
 export const eigaHistoryChapters = pgTable(
@@ -25,12 +27,22 @@ export const eigaHistoryChapters = pgTable(
       .defaultNow()
   },
   (table) => [
-    unique("unique_chap_id_eiga_history_id_idx").on(table.chapId, table.eigaHistoryId),
+    unique("unique_chap_id_eiga_history_id_idx").on(
+      table.chapId,
+      table.eigaHistoryId
+    ),
     index("eiga_history_id_idx").on(table.eigaHistoryId)
-    // foreignKey({
-    //   columns: [table.historyId],
-    //   foreignColumns: [eigaHistories.id]
-    // // deno-lint-ignore no-explicit-any
-    // }) as unknown as any
   ]
+)
+
+export const eigaHistoryChaptersRelations = relations(
+  eigaHistoryChapters,
+  ({ one }) => {
+    return {
+      eigaHistory: one(eigaHistories, {
+        fields: [eigaHistoryChapters.eigaHistoryId],
+        references: [eigaHistories.id]
+      })
+    }
+  }
 )

--- a/serverless/deno.json
+++ b/serverless/deno.json
@@ -36,5 +36,13 @@
     "jsx": "precompile",
     "jsxImportSource": "hono/jsx"
   },
-  "nodeModulesDir": "none"
+  "nodeModulesDir": "none",
+  "deploy": {
+    "project": "309bc9ed-d904-45c6-ab2d-3e27eb93094a",
+    "exclude": [
+      "**/node_modules"
+    ],
+    "include": [],
+    "entrypoint": "main.ts"
+  }
 }

--- a/serverless/deno.json
+++ b/serverless/deno.json
@@ -28,7 +28,7 @@
   },
   "tasks": {
     "start": "deno run --allow-net main.ts",
-    "dev": "deno run -A main.ts",
+    "dev": "deno run -A --watch main.ts",
     "xata:init": "deno run -A npm:@xata.io/cli init",
     "open:studio": "deno run -A npm:drizzle-kit studio"
   },

--- a/serverless/deno.json
+++ b/serverless/deno.json
@@ -40,7 +40,9 @@
   "deploy": {
     "project": "309bc9ed-d904-45c6-ab2d-3e27eb93094a",
     "exclude": [
-      "**/node_modules"
+      "**/node_modules",
+      "drizzle/*.sql",
+      "drizzle/meta/*.json"
     ],
     "include": [],
     "entrypoint": "main.ts"

--- a/serverless/drizzle/0002_living_madripoor.sql
+++ b/serverless/drizzle/0002_living_madripoor.sql
@@ -1,0 +1,4 @@
+DROP INDEX "eiga_history_user_id_eiga_text_id_idx";--> statement-breakpoint
+ALTER TABLE "eiga_histories" ADD COLUMN "source_id" text NOT NULL;--> statement-breakpoint
+CREATE INDEX "eiga_history_source_id_idx" ON "eiga_histories" USING btree ("source_id");--> statement-breakpoint
+CREATE INDEX "eiga_history_user_id_source_id_eiga_text_id_idx" ON "eiga_histories" USING btree ("user_id","source_id","eiga_text_id");

--- a/serverless/drizzle/0003_hard_gressill.sql
+++ b/serverless/drizzle/0003_hard_gressill.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "eiga_history_source_id_user_id_idx" ON "eiga_histories" USING btree ("user_id","source_id");

--- a/serverless/drizzle/meta/0002_snapshot.json
+++ b/serverless/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,381 @@
+{
+  "id": "6890a6ef-f0e1-402f-b871-195f0a8b1b1b",
+  "prevId": "d6f87d04-0bed-4986-8747-4fa6da6d385b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.eiga_histories": {
+      "name": "eiga_histories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "eiga_histories_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eiga_text_id": {
+          "name": "eiga_text_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poster": {
+          "name": "poster",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_name": {
+          "name": "season_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_to": {
+          "name": "for_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "v_chap": {
+          "name": "v_chap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eiga_history_user_id_idx": {
+          "name": "eiga_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eiga_history_source_id_idx": {
+          "name": "eiga_history_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eiga_history_for_to_idx": {
+          "name": "eiga_history_for_to_idx",
+          "columns": [
+            {
+              "expression": "for_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eiga_history_user_id_source_id_eiga_text_id_idx": {
+          "name": "eiga_history_user_id_source_id_eiga_text_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eiga_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eiga_history_v_chap_idx": {
+          "name": "eiga_history_v_chap_idx",
+          "columns": [
+            {
+              "expression": "v_chap",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eiga_histories_user_id_users_id_fk": {
+          "name": "eiga_histories_user_id_users_id_fk",
+          "tableFrom": "eiga_histories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "eiga_histories_v_chap_eiga_history_chapters_id_fk": {
+          "name": "eiga_histories_v_chap_eiga_history_chapters_id_fk",
+          "tableFrom": "eiga_histories",
+          "tableTo": "eiga_history_chapters",
+          "columnsFrom": [
+            "v_chap"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "eiga_histories_for_to_eiga_histories_id_fk": {
+          "name": "eiga_histories_for_to_eiga_histories_id_fk",
+          "tableFrom": "eiga_histories",
+          "tableTo": "eiga_histories",
+          "columnsFrom": [
+            "for_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eiga_history_chapters": {
+      "name": "eiga_history_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "eiga_history_chapters_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "eiga_history_id": {
+          "name": "eiga_history_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cur": {
+          "name": "cur",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dur": {
+          "name": "dur",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chap_id": {
+          "name": "chap_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eiga_history_id_idx": {
+          "name": "eiga_history_id_idx",
+          "columns": [
+            {
+              "expression": "eiga_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_chap_id_eiga_history_id_idx": {
+          "name": "unique_chap_id_eiga_history_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chap_id",
+            "eiga_history_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(28)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/serverless/drizzle/meta/0003_snapshot.json
+++ b/serverless/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,402 @@
+{
+  "id": "9cc5291e-5ace-4dd8-9c09-77443bf4a185",
+  "prevId": "6890a6ef-f0e1-402f-b871-195f0a8b1b1b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.eiga_histories": {
+      "name": "eiga_histories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "eiga_histories_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eiga_text_id": {
+          "name": "eiga_text_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poster": {
+          "name": "poster",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_name": {
+          "name": "season_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "for_to": {
+          "name": "for_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "v_chap": {
+          "name": "v_chap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eiga_history_user_id_idx": {
+          "name": "eiga_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eiga_history_source_id_idx": {
+          "name": "eiga_history_source_id_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eiga_history_for_to_idx": {
+          "name": "eiga_history_for_to_idx",
+          "columns": [
+            {
+              "expression": "for_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eiga_history_source_id_user_id_idx": {
+          "name": "eiga_history_source_id_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eiga_history_user_id_source_id_eiga_text_id_idx": {
+          "name": "eiga_history_user_id_source_id_eiga_text_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eiga_text_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eiga_history_v_chap_idx": {
+          "name": "eiga_history_v_chap_idx",
+          "columns": [
+            {
+              "expression": "v_chap",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eiga_histories_user_id_users_id_fk": {
+          "name": "eiga_histories_user_id_users_id_fk",
+          "tableFrom": "eiga_histories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "eiga_histories_v_chap_eiga_history_chapters_id_fk": {
+          "name": "eiga_histories_v_chap_eiga_history_chapters_id_fk",
+          "tableFrom": "eiga_histories",
+          "tableTo": "eiga_history_chapters",
+          "columnsFrom": [
+            "v_chap"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "eiga_histories_for_to_eiga_histories_id_fk": {
+          "name": "eiga_histories_for_to_eiga_histories_id_fk",
+          "tableFrom": "eiga_histories",
+          "tableTo": "eiga_histories",
+          "columnsFrom": [
+            "for_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eiga_history_chapters": {
+      "name": "eiga_history_chapters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "eiga_history_chapters_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "eiga_history_id": {
+          "name": "eiga_history_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cur": {
+          "name": "cur",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dur": {
+          "name": "dur",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chap_id": {
+          "name": "chap_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eiga_history_id_idx": {
+          "name": "eiga_history_id_idx",
+          "columns": [
+            {
+              "expression": "eiga_history_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_chap_id_eiga_history_id_idx": {
+          "name": "unique_chap_id_eiga_history_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chap_id",
+            "eiga_history_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "users_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(28)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/serverless/drizzle/meta/_journal.json
+++ b/serverless/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1743340258349,
       "tag": "0001_worried_blue_shield",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1743680118663,
+      "tag": "0002_living_madripoor",
+      "breakpoints": true
     }
   ]
 }

--- a/serverless/drizzle/meta/_journal.json
+++ b/serverless/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1743680118663,
       "tag": "0002_living_madripoor",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1743738307818,
+      "tag": "0003_hard_gressill",
+      "breakpoints": true
     }
   ]
 }

--- a/serverless/logic/single.ts
+++ b/serverless/logic/single.ts
@@ -1,0 +1,10 @@
+export function single<T>(results: T[]): T | null {
+  if (results.length === 0) {
+    return null
+  }
+  if (results.length > 1) {
+    throw new Error("Expected one result, but got multiple.")
+  }
+
+  return results[0]
+}

--- a/serverless/logic/use-user.ts
+++ b/serverless/logic/use-user.ts
@@ -1,5 +1,5 @@
-import { Context } from "hono"
-import { MetaUser } from "./get-user.ts"
+import type { Context } from "hono"
+import type { MetaUser } from "./get-user.ts"
 
 export function useUser(ctx: Context): MetaUser {
   return ctx.env.user

--- a/serverless/main.ts
+++ b/serverless/main.ts
@@ -5,6 +5,7 @@ import { etag } from "hono/etag"
 import { bearerAuth } from "hono/bearer-auth"
 import { getUser } from "./logic/get-user.ts"
 
+import { app as appGetWatchHistory } from "./api/eiga/get-watch-history.ts"
 import { app as appGetWatchTimeEpisodes } from "./api/eiga/get-watch-time-episodes.ts"
 import { app as appGetWatchTime } from "./api/eiga/get-watch-time.ts"
 import { app as appSetWatchTime } from "./api/eiga/set-watch-time.ts"
@@ -31,6 +32,7 @@ app.use(
   })
 )
 
+app.route("/api", appGetWatchHistory)
 app.route("/api", appGetWatchTimeEpisodes)
 app.route("/api", appGetWatchTime)
 app.route("/api", appSetWatchTime)


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Implemented online watch history tracking for Hoyomi.
  - Added `EigaWatchTimeGeneralMixin` for services without authentication.
  - Introduced `sourceId` to track watch history across multiple sources.
  - Updated database schema with new columns and indexes for `eiga_histories`.

- Refactored authentication and history mixins.
  - Replaced `EigaHistoryMixin` with `EigaWatchTimeMixin` for unified history handling.
  - Enhanced `AuthMixin` to include `$noAuth` property for better service compatibility.

- Improved API endpoints for watch history and time management.
  - Added new endpoints for fetching and setting watch history and time.
  - Optimized SQL queries for better performance and consistency.

- Enhanced error handling and user state management.
  - Introduced `getUserAsync` method for reliable user state retrieval.
  - Added handling for `UserNotFoundException` in various components.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>26 files</summary><table>
<tr>
  <td><strong>main.dart</strong><dd><code>Removed unused `authInit` property from `TruyenGGService`.</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-695aa2d1582c5eeedb1fc08558a5cf03d7ad94cf1d64392fbdfb77d684588b39">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>eiga_auth_mixin.dart</strong><dd><code>Added `$noAuth` property to `EigaAuthMixin`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-7ba084b163b60e4223b064e6c4784d91cac726fb3e299891f335ed5dd627f632">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>eiga_history_mixin.dart</strong><dd><code>Removed `EigaHistoryMixin` in favor of `EigaWatchTimeMixin`.</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-c5c7b2a2f39820be8e0b684584317761510ec907dec838e9766b169abd8851f4">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>eiga_watch_time_general_mixin.dart</strong><dd><code>Added `EigaWatchTimeGeneralMixin` for general watch time support.</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-945625400afde250958d2f5cbde9eb2f0ac9e838c05e6f8dea21e7178c771b68">+290/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>eiga_watch_time_mixin.dart</strong><dd><code>Updated `EigaWatchTimeMixin` to include history fetching.</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-4af1d257ffb67713e36f59834c5b0b127531539ee5aed5ec21c0b6157e05ebaa">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.dart</strong><dd><code>Removed <code>EigaHistoryMixin</code> and <code>AuthMixin</code> from <code>AnimeVietsubService</code>.</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-b4919a3721da11dd0013a4819e2d7d76c0958b2f41cebb0cc5e5a34beeb9d498">+2/-32</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.dart</strong><dd><code>Added `EigaWatchTimeGeneralMixin` to `KKPhimService`.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-c491b824a0f8ec41329251662e67a0f918deb8ba436d8f196425ba1571d0cdbd">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.dart</strong><dd><code>Added `EigaWatchTimeGeneralMixin` to `NguonCService`.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-d07cd08a43234f86e5cde94203775c7d6d84f23f102547a3af95e274c210dfc8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.dart</strong><dd><code>Added `EigaWatchTimeGeneralMixin` to `OPhimService`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-eb689b330e98a00b18e6ec695b1371abe2e6ffd4fb76da6208f3c5ffbe0d6b67">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>auth_mixin.dart</strong><dd><code>Enhanced `AuthMixin` with `$noAuth` property and support method.</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-0d673a50d01911046af69c522da640e1ee6370d027c5e0564f517f6c1ef8bb0c">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>[comicId].page.dart</strong><dd><code>Updated UI components to check `$noAuth` property.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-d9bb6aeac4195a5b3ce2675a4874aa6ccc8c2c14381f6b9535f749df3dc1df87">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>[sourceId].page.dart</strong><dd><code>Replaced `EigaHistoryMixin` with `EigaWatchTimeMixin`.</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-02a5814e84c6d8c65cb415af62e42fc2cf0728be271b10f7cb4b22bd0a2129d2">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>library_page.dart</strong><dd><code>Updated history handling to use `EigaWatchTimeMixin`.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-e18d6c39ef5d5c56ecd7fbfde91aa4b07e506e35634ab30f9083d722d821f7c3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>authentication.dart</strong><dd><code>Added `getUserAsync` method for asynchronous user state retrieval.</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-a1d78a3b59b70e7463f9dc62af13ba4a963190a2f81b2422de9449b4ac6fe4f9">+24/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get-watch-history.ts</strong><dd><code>Added API endpoint for fetching watch history.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-12e774db7c8cd3137aefe9cd3b876dff810a3e65bd8dd24181d32cfef5ea8530">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get-watch-time-episodes.ts</strong><dd><code>Updated API endpoint for fetching watch time episodes.</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-9a97c79e724656df17716817b058ffa0b59197af5e6c27480aeea383267758b6">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>get-watch-time.ts</strong><dd><code>Updated API endpoint for fetching watch time.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-c0b2ace930e793bf2b24f0c803af3a56d621115cdc8b48e990b759aa9a40a939">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>set-watch-time.ts</strong><dd><code>Updated API endpoint for setting watch time.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-7c10d38608911e697dfceae730916ae4d7b50df04ff0a23a1798c19f4553124b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>eiga_histories.ts</strong><dd><code>Added `sourceId` column and indexes to `eiga_histories`.</code>&nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-a41a3cb6bdcfee04a86616df0d918cc6df4308860bb3f9d3343ac669936db451">+18/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>eiga_history_chapters.ts</strong><dd><code>Added relations for `eiga_history_chapters`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-7e35f993bc24fc6519fc35de59375b13f7d50d3d1e49bcc1ed13f101ab5b0a81">+18/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>single.ts</strong><dd><code>Added utility function for single result retrieval.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-524d959df601d1af566ffe159c4074541f2a7c8bbb7dccf6f33800155e0b89fe">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use-user.ts</strong><dd><code>Updated `useUser` to use type imports.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-cc84a10b7d808ea24f1b83375c797345d42392176a885f23aa0af92cc3d14ffe">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.ts</strong><dd><code>Integrated new API routes for watch history and time.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-e15790fe3f84a104ca789695e099f6caf6a9af446d7887fcdb51e2b8ab51a553">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>eiga.ts</strong><dd><code>Refactored `Eiga` service for watch history and time handling.</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-979e728dce7fb07bff5d8ed57d63af10dae43c63c870d7e24f53d1da706b2a21">+282/-123</a></td>

</tr>

<tr>
  <td><strong>0002_living_madripoor.sql</strong><dd><code>Added SQL migration for `sourceId` column and indexes.</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-3df1eef376231c8c13bcb8ca6c0d151b9a16f0cf68b0ccb42ae32be4853d9e92">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0003_hard_gressill.sql</strong><dd><code>Added SQL migration for additional index on `eiga_histories`.</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-d2841dd959451b35e4b5c95b56c96f23b6bb5879a8e4d1bc2f08c7d3f6cdb209">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>[eigaId].page.dart</strong><dd><code>Added error handling for `UserNotFoundException`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-4dd49dee7f6d56b8211b99db61535fa9e68e01848cd88757e8aa3fd05d933718">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>list_episodes.dart</strong><dd><code>Added error handling for `UserNotFoundException` in episode fetching.</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-155d4867f9e8ad63ce9838ce526f1541828f22331d94ab1d2d45a9c045133dc5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>player_eiga.dart</strong><dd><code>Improved error handling for watch time retrieval.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-de656e6fe86adbac61295bc1857da79484f71f42317a8f2431d0dcb35776d760">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>deno.json</strong><dd><code>Updated Deno configuration for deployment and development.</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-5ed69d96ff609fb7a665d05731041dc9f29e665cb69b3d8bec783a5a2c67884c">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0002_snapshot.json</strong><dd><code>Updated database schema snapshot for migration 0002.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-b47521e073a940aa8ff97f256b80fe3d64fca613408ecacb98ac0a420354e7ed">+381/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>0003_snapshot.json</strong><dd><code>Updated database schema snapshot for migration 0003.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-072037e5dfff6cad04342281708aef5055263ceb8b4c25d502687593861b656b">+402/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>_journal.json</strong><dd><code>Updated migration journal with new migrations.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-3dbdd2eb6b4cce69c419e243cdd04119a77d8e271fdbec9820c69a4cc7470d66">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>button_follow_eiga.dart</strong></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-c1e6fed102310a7b736d7ca83e2acc934663643c8302054a46428dc6f2c7f0ce">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>horizontal_eiga_history_list.dart</strong></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-27106b220ee0f8662a939c3cc0d305de03fdeeb991244d2be701b66bafd5d1c9">+14/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>account_service.dart</strong></td>
  <td><a href="https://github.com/tachibana-shin/hoyomi/pull/19/files#diff-c637aa1d88dc71d01e1d736bd0efee49417e8daec705d11e285fd46cb93299ec">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced media watch time tracking and history management, offering users more reliable playback data.
	- Rolled out new service endpoints to support seamless watch history retrieval and update.
	- Added a new method for retrieving user watch history based on source ID.
	- Implemented a new asynchronous method for user authentication retrieval.
	- Added new error handling for watch time updates and retrieval processes.
	- Enhanced API validation for watch time and history endpoints to ensure accurate data handling.
- **Bug Fixes**
	- Improved authentication checks and conditional UI behavior for interactive features like likes and comments.
	- Enhanced error handling across media playback and history views for greater stability.
- **Chores**
	- Streamlined backend schema and service integrations to optimize performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->